### PR TITLE
Adding support for showing the endpoint in json output of the per list api call

### DIFF
--- a/models/wireguard_peer.go
+++ b/models/wireguard_peer.go
@@ -22,6 +22,9 @@ type WireguardPeer struct {
 	// allowed ips
 	AllowedIps []string `json:"allowed_ips"`
 
+	// end point
+	EndPoint string `json:"end_point,omitempty"`
+
 	// peer id
 	// Read Only: true
 	PeerID string `json:"peer_id,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -415,6 +415,9 @@ func init() {
             "type": "string"
           }
         },
+        "end_point": {
+          "type": "string"
+        },
         "peer_id": {
           "type": "string",
           "readOnly": true
@@ -839,6 +842,9 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "end_point": {
+          "type": "string"
         },
         "peer_id": {
           "type": "string",

--- a/swagger.yml
+++ b/swagger.yml
@@ -264,6 +264,8 @@ definitions:
       preshared_key:
         type: string
         minLength: 32
+      end_point :
+        type: string
       allowed_ips:
         type: array
         items:

--- a/wireguard/utils.go
+++ b/wireguard/utils.go
@@ -183,6 +183,11 @@ func getPeerByWGPeer(peer wgtypes.Peer) (*models.WireguardPeer, error) {
 		presharedKey = peer.PresharedKey.String()
 	}
 
+	endPoint := ""
+	if peer.Endpoint != nil {
+		endPoint = peer.Endpoint.String()
+	}
+
 	peerID, err := getPeerID(peer)
 	if err != nil {
 		return nil, err
@@ -193,6 +198,7 @@ func getPeerByWGPeer(peer wgtypes.Peer) (*models.WireguardPeer, error) {
 		PresharedKey: presharedKey,
 		AllowedIps:   allowedIPs,
 		PeerID:       peerID,
+		EndPoint:     endPoint,
 	}, nil
 }
 


### PR DESCRIPTION
To be able to cleanup never used peers we need the endpoint in the output

In case you are not interested in this feature, just delete my PR :)